### PR TITLE
Pipeline update: check filesize, files to not copy, folder copy scenario

### DIFF
--- a/knowledge-portal/central/.gitlab-ci.yml
+++ b/knowledge-portal/central/.gitlab-ci.yml
@@ -4,20 +4,7 @@ merge-request-to-source:
     script:
         - git config --global user.email "Platformteam@detecttechnologies.com"
         - git config --global user.name "Detect Gitlab Bot"
-        - |
-           # Check and reset to previous commit until commit message contains "docs:" keyword; else break out of loop  
-            while true
-            do
-                commit_message=$(git log -1 --format=%B);
-                if [[ ${commit_message} == *"docs:"* ]]
-                then
-                    git reset --soft HEAD~1;
-                else
-                    break;
-                fi
-            done
-             
-        -  bash -c "$(curl -fsSL https://github.com/detecttechnologies/Gitlab-CI-CD-Templates/raw/main/knowledge-portal/central/initiate_push.sh)"
+        - bash -c "$(curl -fsSL https://github.com/detecttechnologies/Gitlab-CI-CD-Templates/raw/main/knowledge-portal/central/initiate-push-to-source.sh)"
     only:
         refs:
             - main

--- a/knowledge-portal/central/README.md
+++ b/knowledge-portal/central/README.md
@@ -16,6 +16,7 @@ include:
 3. Select the role `Maintainer` and `write_repository` as the scope of token.
 4. `Create project access token` will create a unique token for you that can then be shared with `maintainers` setting up individual `source` pipelines.
 
+
 ## Setting up BOT_ACCESS_TOKEN variable 
 
 1. Go to `Settings >> CI/CD >> Variables`
@@ -38,8 +39,8 @@ include:
 - All commits from `Knowledge Portal` starts with commit message `docs:....`
 - We check this substring `docs:` in the commit message to ensure the same.
 
-    Notes: `Knowledge Portal` creates new commits for every changed file, if multiple files on `Knowledge Portal` are modified and saved at almost exact time, the pipeline on `central` repo only runs for latest commit(sometimes). 
-    -  To resolve, this issue, we check all commits starting from the latest commit until `docs:` pattern breaks. 
+    Notes: `Knowledge Portal` creates new commits for every changed file, if multiple files on `Knowledge Portal` are modified and saved at almost exact time, the pipeline on `central` repo only runs for latest commit(best guess: this only happens when you do a `Force Sync` opeartion under `Storage` on wikijs). 
+    -  To resolve, this issue, we check last 5 commits starting from the latest commit until `docs:` pattern break.  
     - A drawback of this implementation is that, it will add commits to same MR incase pipeline actually ran for previous commits as well.    
 
 

--- a/knowledge-portal/central/central-pipeline-checks.py
+++ b/knowledge-portal/central/central-pipeline-checks.py
@@ -1,11 +1,9 @@
-# This script would take in a list of file names and find the reverse mappings
+# This script would take in a list of file names and find the reverse mappings after pipeline checks
 # Assumptions:
 # manifests/<repo_name>.txt: Source repo name should be the manifest name
 # manifests have the convention: `source-->destination`
-import os
-import subprocess
+
 import sys
-import time
 from glob import glob
 
 changed_files = sys.argv[1:]
@@ -28,17 +26,17 @@ for manifest in manifests_lst:
 
         # Get all lines in the manifest as a list
         lines = f.readlines()
-
-        # Split by '-->', take RHS and strip white spaces
-        rhs_lines = [s.split('-->')[1].strip() for s in lines]
         
-        # Iterate through rhs_lines and get lhs_lines for them with rhs as key and lhs as value
-        lhs_lines = {}
-        for rhs_line in rhs_lines:
-            lhs_lines[rhs_line] = [s.split('-->')[0] for s in lines if s.split('-->')[1].strip() == rhs_line]
-
+        # Check if line contains "-->", if yes, strip the line at "-->" and get source and central paths 
+        paths = {}  # central path as key and source path as value 
+        for line in lines:
+            if "-->" in line:
+                central_path = line.split('-->')[1].strip()
+                paths[central_path] = line.split('-->')[0]    
+        
         # Iterate through RHS and see if we find any matches in changed files
-        for rhs_line in rhs_lines:
-            if rhs_line in changed_files:
-                lhs_line = ''.join(map(str, lhs_lines[rhs_line]))
-                print(f"{repo_name}:{rhs_line}-->{lhs_line}")
+        for central_path in paths.keys():  
+            matches = [s for s in changed_files if central_path in s]
+            if matches:
+                source_path = ''.join(map(str, paths[central_path]))
+                print(f"{repo_name}:{central_path}-->{source_path}")

--- a/knowledge-portal/central/initiate-push-to-source.sh
+++ b/knowledge-portal/central/initiate-push-to-source.sh
@@ -1,16 +1,32 @@
 #!/bin/bash
 
+set -e
+
+# Check and reset to previous commit until last 5 commits, if message contains "docs:" keyword; else break out of loop 
+commits_to_check=1
+while [ $commits_to_check -le 5 ]
+do
+    commit_message=$(git log -1 --format=%B);
+    if [[ ${commit_message} == *"docs:"* ]]
+    then
+        git reset --soft HEAD~1
+        ((commits_to_check++))
+    else
+        break
+    fi
+done
+
 # changed files can be obtained by git diff between latest commit and unstaged area
-changed_files=$(git diff --name-only HEAD);
-echo "Files changed in knowledge portal: ${changed_files}";
+changed_files=$(git diff --name-only HEAD)
 
 if [[ $changed_files ]]
 then
+    echo "Files changed in knowledge portal: ${changed_files}"
     # Reverse the git reset and move files to staged as we will need latest files 
     git add -A && git commit -m "docs:reversing soft reset as now we have the filenames"
 
     # Run python script to get output in format "source_repo_name:filepath_central_gitrepo-->filepath_source_gitrepo"
-    output=$(python3 -c "$(curl -fsSL https://github.com/detecttechnologies/Gitlab-CI-CD-Templates/raw/main/knowledge-portal/central/reverse_mapping.py)" $changed_files)
+    output=$(python3 -c "$(curl -fsSL https://github.com/detecttechnologies/Gitlab-CI-CD-Templates/raw/main/knowledge-portal/central/central-pipeline-checks.py)" $changed_files)
     
     # Create an array to keep track of all unique source repos in which files have been modified
     declare -a source_repo_array
@@ -21,9 +37,9 @@ then
         split_output=(${line//":"/ })
         source_repo_name=${split_output[0]}
         split_mapping=(${split_output[1]//"-->"/ })
-        lhs_path=${split_mapping[1]}
-        rhs_path=${split_mapping[0]}
-        echo "lhs_path:${lhs_path}, rhs_path:${rhs_path}, source_repo_name:${source_repo_name}"
+        source_path=${split_mapping[1]}
+        central_path=${split_mapping[0]}
+        echo "source_path:${source_path}, central_path:${central_path}, source_repo_name:${source_repo_name}"
 
         # Create a unique directory for each source repo and copy files
         unique_directory="/root/source/${source_repo_name}"
@@ -34,8 +50,7 @@ then
         if [ -d "$unique_directory" ]
         then
             # Remove existing and Copy changed files to unique_directory
-            rm -rfv ${unique_directory}/${lhs_path}
-            cp -v ./${rhs_path} ${unique_directory}/${lhs_path}
+            cp -rv ./${central_path}/* ${unique_directory}/${source_path}
         else
             # Create directory, clone source repo, create branch, and initiate copy
             mkdir -p ${unique_directory}
@@ -44,8 +59,7 @@ then
             cd ${unique_directory}
             git checkout -B knowledge-portal_changes
             cd -
-            rm -rfv ${unique_directory}/${lhs_path}
-            cp -v ./${rhs_path} ${unique_directory}/${lhs_path}
+            cp -rv ./${central_path}/* ${unique_directory}/${source_path}
         fi
     done <<< ${output} 
     echo "Done"

--- a/knowledge-portal/source/.gitlab-ci.yml
+++ b/knowledge-portal/source/.gitlab-ci.yml
@@ -1,52 +1,10 @@
 copy-to-central-git:
   stage: push
-  image: bitnami/git
+  image: python
   script:
-    - echo "URL:${CI_REPOSITORY_URL}"
-    - |
-      # Extract the unique path (Subpath) from Repository url        
-      unique_path_temp1=(${CI_REPOSITORY_URL//"gitlab.com/"/ })           # split after 'gitlab.com/' 
-      unique_path_temp2=(${unique_path_temp1[1]//"."/ })                  # split before .git
-      unique_path="$( cut -d '/' -f 2- <<< "${unique_path_temp2[0]}" )"   # split after first '/'
-      manifest_suffix=${unique_path//"/"/_}
-      echo "Done, source-repo's path: ${unique_path}, manifest suffix: ${manifest_suffix}"
-
-    - |
-      # Clone the destination repo, copy the source-git's manifest to central-git by adding source-path in manifest filename
-      git clone $CENTRAL_GIT_PUSH_URL /root/dest
-      mkdir -p /root/dest/manifests
-      cp -v docs-manifest.txt /root/dest/manifests/docs-manifest_${manifest_suffix}.txt
-      echo "Done"
-
-    - |
-      # Read every line of the manifest file, and copy it over with the required central-git mapping
-      cat docs-manifest.txt | while read line
-      do
-        if [[ "$line" == *"-->"* ]];
-          then
-            split=(${line//-->/ });
-            source=${split[0]};
-            destination=${split[1]};
-            if [[ "$destination" == *"/"* ]];
-            then
-              path="${destination%/*}"
-              file="${destination##*/}";
-              mkdir -p /root/dest/${path}   # Ensure the destination folder exists at central-git
-              cp -R -v ${source} /root/dest/${path}/${file};    # Copy the source file to the required prefix at central-git
-            fi
-        fi
-      done
-      echo "Done"
-
-    - |
-      # Push back to central-git with the updated changes
-      cd /root/dest
-      git config --global user.email "PlatformTeam@detecttechnologies.com"
-      git config --global user.name "Detect Gitlab Bot"
-      git add -A && git commit -m "Commit in source pipeline for ${unique_path}" --allow-empty;
-      git push origin HEAD:main -f;
-      echo "Done"
-
-  only:
-    refs:
-      - main
+    - bash -c "$(curl -fsSL https://github.com/detecttechnologies/Gitlab-CI-CD-Templates/raw/main/knowledge-portal/source/initiate-push-to-central.sh)"
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+      when: manual
+    - if: $CI_COMMIT_BRANCH == "main"
+      when: always

--- a/knowledge-portal/source/README.md
+++ b/knowledge-portal/source/README.md
@@ -11,7 +11,7 @@ You will have to modify the existing `gitlab-ci.yml` file to include:
         - remote: 'https://github.com/detecttechnologies/Gitlab-CI-CD-Templates/raw/main/knowledge-portal/source/.gitlab-ci.yml'
 
 ```
-## Configure CI/CD variables
+## Configure CI/CD variables (applied on overall gitlab instance)
 
 1. Go to `Settings >> CI/CD >> Variables`
 2. Click on `Add variable`. 
@@ -20,21 +20,42 @@ You will have to modify the existing `gitlab-ci.yml` file to include:
 4. Click on `Add variable` button to confirm changes. 
 
 
-> Ideally the steps of this section can be performed on the overall gitlab instance, so that it need not be replicated for every repo.
+> The steps of this section are being performed on the overall gitlab instance, so that it need not be replicated for every repo.
 
 ## Creating `manifest.txt` file
 
 - The manifest file keeps track of files you choose to import to `central-repo`.
 - It also allows renaming a file and copying the same file to separate destination folders in case you would like to have different views of the same underlying data through force-duplication.
 - The `docs-manifest.txt` file should be created at the root of your project's repository.
+- To explicitly specify a file/subfolder that shouldn't get copied while you are copying entire folder, you can add the source path with `!` in prefix.
 
 An example of a `docs-manifest.txt` file is added below:
 ```txt
+# Mappings
 README.md-->folder1/folder3/hello.md
 README.md-->folder2/README.md
 fol1/read.md-->folder2/read.md
-fol2/-->/
+fol2/-->fol2/
+
+# Don't copy these paths
+!fol2/photo.jpg
+!fol2/anotherfolder/
 ```
 Notes:
 1. (! Important) RHS of `-->` has to be unique across all manifest files.
-2. The last line in the sample above (`fol2/-->/`) shows how a folder can be copied as-is to the destination repo
+2. The last line in the sample above (`fol2/-->fol2/`) shows how a folder can be copied as-is to the destination repo
+
+
+## Source pipeline flow
+- Job `copy-to-central-git` will run 
+    - automatically for any commits on main branch of `source repo`.   
+    - manually for any merge requests created where target branch is `main`.
+- Performs these checks in order
+    - Check if source mapping path exist 
+    - Check if any source path mapping is a folder mapping and create new unique file mappings recursively
+    - Check if manifest file mentions any files/folder which should not get copied and update mappings accordingly
+    - Check if any mappings have spaces in filenames
+    - Check if filesize for any mapping is larger than 500KB
+- If any check fails, the python script exits with an error message and pipeline fails.
+- If all checks pass, the python script outputs mappings which are then used to copy files to `central`.  
+        

--- a/knowledge-portal/source/initiate-push-to-central.sh
+++ b/knowledge-portal/source/initiate-push-to-central.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e
+
+# Run python script for pipeline checks and get mappings if all is well
+output=$(python3 -c "$(curl -fsSL https://github.com/detecttechnologies/Gitlab-CI-CD-Templates/raw/main/knowledge-portal/source/source-pipeline-checks.py)")
+echo "Done, Mappings: ${output}"
+
+# Extract the unique path (Subpath) from Repository url      
+unique_path_temp1=(${CI_REPOSITORY_URL//"gitlab.com/"/ })           # split after 'gitlab.com/' 
+unique_path_temp2=(${unique_path_temp1[1]//"."/ })                  # split before .git
+unique_path="$( cut -d '/' -f 2- <<< "${unique_path_temp2[0]}" )"   # split after first '/'
+manifest_suffix=${unique_path//"/"/_}
+echo "Done, source-repo's path: ${unique_path}, manifest suffix: ${manifest_suffix}"
+
+# Clone the destination repo, copy the source-git's manifest to central-git by adding source-path in manifest filename
+git clone $CENTRAL_GIT_PUSH_URL /root/central
+mkdir -p /root/central/manifests
+cp -v docs-manifest.txt /root/central/manifests/docs-manifest_${manifest_suffix}.txt
+echo "Done, Copied manifest file to central."
+
+# Read all mappings from output and copy accordingly 
+while read line
+do
+    if [[ "$line" == *"-->"* ]]
+    then
+        source_path="${line%-->*}"
+        central_path="${line##*-->}"
+        if [[ "$central_path" == *"/"* ]]
+        then
+            echo "${central_path}"
+            path="${central_path%/*}"
+            file="${central_path##*/}"
+            mkdir -p -v /root/central/${path}
+            cp -v ${source_path} /root/central/${path}/${file}
+        else
+            cp -v ${source_path} /root/central/${central_path}
+        fi
+    fi
+done <<< ${output} 
+echo "Done. Copied all files to central"
+
+# Push back to central-git with the updated changes
+cd /root/central
+git config --global user.email "PlatformTeam@detecttechnologies.com"
+git config --global user.name "Detect Gitlab Bot"
+git add -A && git commit -m "Commit in source pipeline for ${unique_path}" --allow-empty;
+git push origin HEAD:main -f;
+echo "Done finally. Pushed files to central git."
+

--- a/knowledge-portal/source/source-pipeline-checks.py
+++ b/knowledge-portal/source/source-pipeline-checks.py
@@ -1,0 +1,118 @@
+import os
+import sys
+from glob import glob
+
+# Max filesize to be copied over to central
+FILESIZE_LIMIT = 500
+
+# Check if folder copy scenario; if yes, get all files in the folder recursively
+def check_for_folders(source_paths):
+    folder_mappings = {}
+    # Folder mappings expanded to their corresponding recursive file mappings
+    for source_path in source_paths:
+        # Check if source_path is a folder
+        if os.path.exists(source_path):
+            if os.path.isdir(source_path):
+                if source_path.endswith("/"):
+                    mycwd = os.getcwd()
+                    os.chdir(source_path)
+                    files = glob('**/*.*', recursive=True)
+                    os.chdir(mycwd)
+                    folder_mappings[source_path] = files
+                else:
+                    sys.exit(f"Check failed! This folder: {source_path} path doesn't end with (/)")
+        else:
+            sys.exit(f"Check failed! This file/folder: {source_path} mentioned in manifest file doesn't exist or you have not ended your folder copy with (/)")
+    return folder_mappings
+
+
+# source files to delete before copying
+def remove_paths(mappings, source_paths_to_remove):
+    
+    current_source_paths = list(mappings.values())
+    folder_mappings = check_for_folders(current_source_paths)
+   
+   # Update mappings: file-->file mapping from folder
+    for source_path in list(folder_mappings.keys()):
+        central_paths = [i for i in mappings if mappings[i]==source_path]
+        for central_path in central_paths:
+            for file in folder_mappings[source_path]:
+                mappings[f"{central_path}{file}"] = f"{source_path}{file}"
+            del mappings[central_path]
+    # Update mappings by deleting keys mentioned in source_paths to remove
+    for source_path in source_paths_to_remove:
+        if source_path in list(mappings.values()):
+            central_paths = [i for i in mappings if mappings[i]==source_path]
+            if central_path:
+                for central_path in central_paths:
+                    del mappings[central_path]
+    return mappings
+
+# Check for spaces in mappings
+def check_for_spaces(mappings):
+    mappings_with_spaces = {}
+    for mapping in list(mappings.keys()):
+        if " " in mapping or " " in mappings[mapping]:
+            mappings_with_spaces[mapping] = mappings[mapping]
+    if mappings_with_spaces:
+        sys.exit(f"Check failed! Mappings have spaces: {mappings_with_spaces}")
+    else:
+        return mappings
+
+# Check filsize for source mappings 
+def check_filesize(mappings, size):
+    source_paths = list(mappings.values())
+    for source_path in source_paths:
+        if source_path.startswith("/"):
+            source_path = source_path.split("/")[1:]
+            source_path = "/".join(source_path)
+        file_size = (os.stat(source_path).st_size)/1000
+        if file_size > size:
+            sys.exit(f"Check failed: {source_path} is too large to copy (>500KB). Current size: {file_size}.")
+    return mappings
+
+with open("docs-manifest.txt", 'r') as f:
+    lines = f.readlines()
+
+    # Get all lines with '!' pattern
+    lines_with_exclamation = [line.strip() for line in lines if "!" in line]
+
+    # Get all lines with '-->' pattern 
+    lines_with_arrows = [line.strip() for line in lines if "-->" in line]
+        
+    # Get source and central paths as key:value pair
+    # central is key and source is value as central mappings are unique
+    mappings = {}
+    for line in lines_with_arrows: 
+        mappings[line.split('-->')[1].strip()] = line.split('-->')[0].strip()
+    
+    # Get source paths to be removed before coying
+    source_paths_to_remove = [line.split('!')[1].strip() for line in lines_with_exclamation]
+
+    # Check if folders are mentioned in source paths to remove; Convert to file mapping 
+    folder_mappings_to_delete = check_for_folders(source_paths_to_remove)
+    
+    # Update source paths to delete list: Add file paths and remove folder path
+    for key in folder_mappings_to_delete.keys():
+        files = [f"{key}{file}" for file in folder_mappings_to_delete[key]]
+        source_paths_to_remove.extend(files)
+        source_paths_to_remove.remove(key)
+    
+    # Update mappings based on source_paths_to_remove
+    mappings = remove_paths(mappings, source_paths_to_remove)
+    
+    # Check if mappings have spaces
+    mappings = check_for_spaces(mappings)
+
+    # Check if filesize of a mapping is >500KB
+    mappings = check_filesize(mappings, FILESIZE_LIMIT)
+
+    # Write to bash output variable if all checks pass
+    mapping_array = []
+    for mapping in mappings.keys(): 
+        mapping_array.append(f"{mappings[mapping]}-->{mapping}") 
+
+    # Print to stdout
+    for mapping in mapping_array:
+        print(mapping)
+    


### PR DESCRIPTION
- renamed py and bash script files to a more appropriate name
- added source pipeline checks: if path exists, if path have spaces, if filesize>500KB
- source files which shouldn't be copied can be declared in manifest
- handle spaces and comments in manifest
- look back 5 commits on central instead of until "docs:" pattern
- updated README