### PR TITLE
Change to toml for SourceGit-CentralGit sync, search for image-mappings explicitly, add additional data validations

### DIFF
--- a/knowledge-portal/central/.gitlab-ci.yml
+++ b/knowledge-portal/central/.gitlab-ci.yml
@@ -1,10 +1,14 @@
-merge-request-to-source:
-    stage: push
-    image: python
-    script:
-        - git config --global user.email "Platformteam@detecttechnologies.com"
-        - git config --global user.name "Detect Gitlab Bot"
-        - bash -c "$(curl -fsSL https://github.com/detecttechnologies/Gitlab-CI-CD-Templates/raw/main/knowledge-portal/central/initiate-push-to-source.sh)"
-    only:
-        refs:
-            - main
+merge_request_to_source:
+  stage: push
+  image: python:3.9
+  before_script:
+    - pip3 install toml
+  script:
+    - bash -c "$(curl -fsSL https://github.com/detecttechnologies/Gitlab-CI-CD-Templates/raw/main/knowledge-portal/central/initiate-push-to-source.sh)"
+
+workflow:
+  rules:
+    - if: $CI_COMMIT_MESSAGE =~ /^docs:.*/ && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      when: always
+    - when: never
+  

--- a/knowledge-portal/central/README.md
+++ b/knowledge-portal/central/README.md
@@ -1,4 +1,4 @@
-# Knowledge Portal Central Pipeline
+# Knowledge Portal Central Git
 
 ## Usage
 
@@ -17,39 +17,42 @@ variables:
   GIT_STRATEGY: clone
 
 ```
+> Image mappings for a markdown file get generated dynamically in the pipeline, and get copied over to Knowledge Portal. However, there are some conditions which are explained in section [central pipeline checks](#central-pipeline-checks). 
+
+## Additional Information 
 
 ### Central Pipeline Checks
 
-Before the job in pipeline pushes files back to `source`, it checks multiple things based on your mapping file. Knowing about these checks will help you use the pipeline easily and make any necessary changes before any change on wikijs become available at `source` repository.
+Before the job in pipeline pushes files back to `source`, it checks multiple things based on your mapping file. Knowing about these checks will help you use the pipeline easily and make any necessary changes before any change on Knowledge Portal  become available at `source` repository.
 
-- The jobs will only run when a commit happens on `main` branch with a message starting with `docs:`, This ensures that the jobs will only run when a commit has been made from wikijs portal.
-- Ensure that all image URL paths in Markdown files are absolute and begin with `/`.
-- Ensure all image URL paths in a Markdown file are in downstream of that Markdown file. 
+- The jobs will only run when a commit happens on `main` branch of central git with a message starting with `docs:`, This ensures that the jobs will only run when a commit has been made from Knowledge Portal.
 - Ensure that any file being copied is less than 500KB in size.
+- Pipeline figures out the type of image path specified in a markdown file, and converts any relative image path to absolute path before copying over to Knowledge Portal. Any path starting with `http` will not be changed in the markdown file.
 
-## Use Cases: Changes on Knowledge Portal
+### Use Cases: Changes on Knowledge Portal
 
 If you adhere to checks performed by **Central Pipeline**, you can use the pipeline for following use cases:
 
-### Uploading/Deleting an image on Knowldge Portal
+#### Uploading/Deleting an image on Knowldge Portal
 
 - The pipeline will run as a new commit will happen at `central` with a commit message starting with `docs:`
 - Since, no Markdown files have been changed since last commit, the pipeline will succed with a message "**This is not a markdown file change scenario.**"
 
-### Creating a new Markdown file on Knowldge Portal
+#### Creating a new Markdown file on Knowldge Portal
 
 - If the Markdown file has been created inside a folder which exists in central mapping of `docs-manifest.toml` file, the file will be made available at the `source` as well in the MR that will get created once Knowledge Portal syncs with `central`.
 - In case of new images in the markdown file,the new image will be made available at `source` with a modified absolute path in `source` repository.
 
-### Deleting a Markdown file on Knowldge Portal
+#### Deleting a Markdown file on Knowldge Portal
 
 - If the file that has been deleted is part of any `source` repository
-    - the files will get deleted on wikijs and in turn on `central` repository.
+    - the files will get deleted on Knowledge Portal and in turn on `central` repository.
     - the pipeline however is not configured to deal with such situations,
         - so, the change won't sync back to source, and the pipeline will succed with a message "**This is not a markdown file change scenario.**".
-        - if the file still exists at source, it will become available at   `central` and in turn on `Knowldge Portal` again, when the pipeline on `source` runs.  
+        - if the file still exists at source, it will become available at `central` and in turn on `Knowldge Portal` again, when the pipeline on `source` runs.  
+- Same scenario will apply for a file created in a `folder mapping` which is first synced at `source` and then deleted  
 
-## Edge Cases
+### Edge Cases
 
 1. Handling duplicates of the same file in different locations at `central`, with simultaneous modifications
     - If the same file exists in multiple locations (duplicates) at `central`, and both files are modified at the same time, the file mentioned later in the `docs-manifest` file (i.e., `duplicate2`) will take precedence and be pushed back to the `source` repository as the truth.

--- a/knowledge-portal/central/central-pipeline-checks.py
+++ b/knowledge-portal/central/central-pipeline-checks.py
@@ -1,42 +1,177 @@
-# This script would take in a list of file names and find the reverse mappings after pipeline checks
-# Assumptions:
-# manifests/<repo_name>.txt: Source repo name should be the manifest name
-# manifests have the convention: `source-->destination`
-
 import sys
 from glob import glob
+import toml
+import re
+import os
 
 changed_files = sys.argv[1:]
-manifests_lst = glob("manifests/*.txt")
 
-for manifest in manifests_lst:
-    # Key-value store with schema repo_name:[changed_files]
-    mappings = {}
+CHANGED_FILES = [file for file in changed_files if file.endswith(".md")] 
+MANIFEST_LST = glob("manifests/*.toml")
+FILESIZE_LIMIT = 500
 
-    # remove /manifests
-    repo_name = manifest.split('/')[1]
 
-    # remove .txt
-    repo_name = repo_name.split('.')[0]
+def load_manifests(manifest_file):
+    manifest_json = toml.load(manifest_file)
+    mappings = manifest_json["includes"]
+    return mappings
 
-    # remove docs-manifest_
-    repo_name = repo_name.split('docs-manifest_')[1]
-    
-    with open(manifest, 'r') as f:
+def get_repo_name(manifest_file):
+    repo_name = manifest_file.split('/')[1]           # remove /manifests
+    repo_name = repo_name.split('.')[0]               # remove .toml
+    repo_name = repo_name.split('docs-manifest_')[1]  # remove docs-manifest_
+    return repo_name
 
-        # Get all lines in the manifest as a list
-        lines = f.readlines()
+def get_md_file_paths(central_path):
+    md_files = glob(os.path.join(central_path, "**/*.md"), recursive=True)
+    return md_files
+
+
+def get_updated_mappings(changed_files, mapppings):
+    updated_mappings = {}
+    for source_path, central_paths in mapppings.items():
+        for central_path in central_paths:
+            
+            # Check if central path is a folder path 
+            if not os.path.isdir(central_path):
+                md_file_paths = []
+            else:
+                # From a folder path get all md file paths
+                md_file_paths = get_md_file_paths(central_path)
+
+            # Update the mapping json if folder paths are present 
+            if md_file_paths:
+                for md_file_path in md_file_paths:
+                    if md_file_path in changed_files:
+                        file_path = md_file_path.split(central_path)[1] # Gives you relative path from folder mapping defined in manifest
+                        new_source_path = os.path.join(source_path, file_path) 
+                        updated_mappings[md_file_path] = new_source_path
+            else:
+                if central_path in changed_files:
+                    updated_mappings[central_path] = source_path
+    return updated_mappings
+
+def find_images(central_path):
+    with open(central_path, "r") as f:
+        content = f.read()
+    image_regex = r"!\[.*\]\((.+)\)"
+    images = re.findall(image_regex, content)
+    updated_images = [image.strip() for image in images if not image.startswith("http")]
+    return updated_images
+
+
+def check_filesize(path):
+    file_size = (os.stat(str(path)).st_size)/1000
+    if file_size > FILESIZE_LIMIT:
+        sys.exit(f"Error: {central_path} is too large to copy (>500KB). Current size: {file_size}.")
+    else:
+        return True
+
+def normalize_path(path):
+  
+    # Split the path into components
+    components = path.split('/')
+
+    # Initialize an empty list to hold the normalized components
+    normalized_components = []
+
+    # Loop through the components and build the normalized path
+    for component in components:
+        # Ignore empty components and '.'
+        if component == '' or component == '.':
+            continue
+        # Handle '..' by removing the last normalized component
+        elif component == '..':
+            if len(normalized_components) > 0:
+                normalized_components.pop()
+        # Add all other components to the normalized path
+        else:
+            normalized_components.append(component)
+
+    # Join the normalized components and return the result
+    normalized_path = '/'.join(normalized_components)
+    return normalized_path
+
+
+def create_image_mappings(updated_mappings):
+    all_image_mappings = {}
+    for central_path, source_path in updated_mappings.items():
+        central_folder = os.path.dirname(central_path)
+        source_folder = os.path.dirname(source_path)
+        images = find_images(central_path)
+        if images:
+            # Create source and central image mappings
+            image_mappings_array = []
+            for central_image_path in images:
+                image_mappings = {}
+                if central_image_path.startswith("/"):
+                    # rel_central and abs_central are assumed same in this case
+                    abs_central_image_path = central_image_path[1:]
+                    rel_central_image_path = abs_central_image_path
+                    rel_path = os.path.relpath(rel_central_image_path, central_folder)
+                    abs_source_image_path = os.path.join(source_folder, rel_path)
+                    # normalize_path function helps in removing /../ or /./ present in entire path string
+                    abs_source_image_path = normalize_path(abs_source_image_path)
+                else:
+                    rel_central_image_path = central_image_path
+                    abs_central_image_path = os.path.join(central_folder, rel_central_image_path)
+                    abs_central_image_path = normalize_path(abs_central_image_path)
+                    abs_source_image_path = os.path.join(source_folder, rel_central_image_path)
+                    abs_source_image_path = normalize_path(abs_source_image_path)
+
+                # Check image filesize
+                check_filesize(abs_central_image_path)
         
-        # Check if line contains "-->", if yes, strip the line at "-->" and get source and central paths 
-        paths = {}  # central path as key and source path as value 
-        for line in lines:
-            if "-->" in line:
-                central_path = line.split('-->')[1].strip()
-                paths[central_path] = line.split('-->')[0]    
+                image_mappings["rel_central"] = rel_central_image_path
+                image_mappings["abs_central"] = abs_central_image_path
+                image_mappings["abs_source"] = abs_source_image_path
+                image_mappings_array.append(image_mappings)
+
+            all_image_mappings[central_path] = image_mappings_array
+
+    return all_image_mappings
+
+def modify_image_paths(updated_mappings, all_image_mappings):
+    for central_path, source_path in updated_mappings.items():
+        image_mappings = all_image_mappings.get(central_path, [])
+        if image_mappings:
+            with open(central_path, "r") as f:
+                content = f.read()
+            for image_mapping in image_mappings:
+                original = image_mapping["rel_central"]
+                new = image_mapping["abs_source"]
+                    
+                if original == image_mapping["abs_central"]:
+                    content = content.replace(original, new)
+                else:
+                    # if rel_path and abs_path are not same add a '/' in central_image_path. In other case, it's already there in file.
+                    content = content.replace(original, f"/{new}")
+            with open(central_path, "w") as f:
+                f.write(content)
+    return True
+
+
+# Load all manifests and get file_mapppings and image_mappings one by one
+for manifest_file in MANIFEST_LST:
+    mappings = load_manifests(manifest_file)
+
+    # Get repository name for this manifest file
+    repo_name = get_repo_name(manifest_file) 
+
+    # Check if changed file path exists in central paths of file mappings
+    updated_mappings = get_updated_mappings(CHANGED_FILES, mappings)
+
+    # Get all image mappings for updated mappings which are also valid mappings for this commit if they exist
+    if updated_mappings:
+        all_image_mappings = create_image_mappings(updated_mappings)
+        modify_image_paths(updated_mappings, all_image_mappings)
+
+        # Print to bash output
+        for central_path, source_path in updated_mappings.items():
+            print(f"{repo_name}:{central_path}-->{source_path}")    
         
-        # Iterate through RHS and see if we find any matches in changed files
-        for central_path in paths.keys():  
-            matches = [s for s in changed_files if central_path in s]
-            if matches:
-                source_path = ''.join(map(str, paths[central_path]))
-                print(f"{repo_name}:{central_path}-->{source_path}")
+            image_mappings = all_image_mappings.get(central_path, [])
+            for image_mapping in image_mappings:
+                central_image = image_mapping["abs_central"]
+                source_image = image_mapping["abs_source"]
+                print(f"{repo_name}:{central_image}-->{source_image}")

--- a/knowledge-portal/central/initiate-push-to-source.sh
+++ b/knowledge-portal/central/initiate-push-to-source.sh
@@ -2,21 +2,12 @@
 
 set -e
 
-# Check and reset to previous commit until last 5 commits, if message contains "docs:" keyword; else break out of loop 
-commits_to_check=1
-while [ $commits_to_check -le 5 ]
-do
-    commit_message=$(git log -1 --format=%B);
-    if [[ ${commit_message} == *"docs:"* ]]
-    then
-        git reset --soft HEAD~1
-        ((commits_to_check++))
-    else
-        break
-    fi
-done
+# Set credentials
+git config --global user.email "PlatformTeam@detecttechnologies.com"
+git config --global user.name "Detect Gitlab Bot"
 
 # changed files can be obtained by git diff between latest commit and unstaged area
+git reset --soft HEAD~1
 changed_files=$(git diff --name-only HEAD)
 
 if [[ $changed_files ]]
@@ -34,35 +25,44 @@ then
     # From python output, separate line to corresponding variables 
     while read line 
     do
-        split_output=(${line//":"/ })
-        source_repo_name=${split_output[0]}
-        split_mapping=(${split_output[1]//"-->"/ })
-        source_path=${split_mapping[1]}
-        central_path=${split_mapping[0]}
-        echo "source_path:${source_path}, central_path:${central_path}, source_repo_name:${source_repo_name}"
-
-        # Create a unique directory for each source repo and copy files
-        unique_directory="/root/source/${source_repo_name}"
-        
-        # Get source_repo_path by changing '_' to '/'
-        source_repo_path=${source_repo_name//'_'/'/'} 
-        
-        if [ -d "$unique_directory" ]
+        if [ "$line" ]
         then
-            # Remove existing and Copy changed files to unique_directory
-            cp -rv ./${central_path}/* ${unique_directory}/${source_path}
+            split_output=(${line//":"/ })
+            source_repo_name=${split_output[0]}
+            split_mapping=(${split_output[1]//"-->"/ })
+            source_path=${split_mapping[1]}
+            central_path=${split_mapping[0]}
+            echo "source_path:${source_path}, central_path:${central_path}, source_repo_name:${source_repo_name}"
+
+            # Create a unique directory for each source repo and copy files
+            unique_directory="/root/source/${source_repo_name}"
+            
+            # Get source_repo_path by changing '_' to '/'
+            source_repo_path=${source_repo_name//'_'/'/'} 
+            
+            if [ -d "$unique_directory" ]
+            then
+                # Remove existing and Copy changed files to unique_directory
+                source_path_dir=$(dirname "${source_path}")
+                mkdir -pv ${unique_directory}/${source_path_dir}
+                cp -v ${central_path} ${unique_directory}/${source_path}
+            else
+                # Create directory, clone source repo, create branch, and initiate copy
+                mkdir -p ${unique_directory}
+                source_repo_array+=( "${source_repo_name}" )
+                git clone -v https://oauth2:${BOT_ACCESS_TOKEN}@gitlab.com/DetectTechnologies/${source_repo_path}.git ${unique_directory}
+                cd ${unique_directory}
+                git checkout -B knowledge-portal_changes
+                cd -
+                source_path_dir=$(dirname "${source_path}")
+                mkdir -pv ${unique_directory}/${source_path_dir}
+                cp -v ${central_path} ${unique_directory}/${source_path}
+            fi
         else
-            # Create directory, clone source repo, create branch, and initiate copy
-            mkdir -p ${unique_directory}
-            source_repo_array+=( "${source_repo_name}" )
-            git clone -v https://oauth2:${BOT_ACCESS_TOKEN}@gitlab.com/DetectTechnologies/${source_repo_path}.git ${unique_directory}
-            cd ${unique_directory}
-            git checkout -B knowledge-portal_changes
-            cd -
-            cp -rv ./${central_path}/* ${unique_directory}/${source_path}
+            echo "This is not a markdown file change scenario."
         fi
     done <<< ${output} 
-    echo "Done"
+    echo "Done. Copied all files."
     
     # Push all changes to source repos and create merge requests
     for source_repo in "${source_repo_array[@]}"
@@ -74,7 +74,4 @@ then
         git push -f -o merge_request.create -o merge_request.draft -o merge_request.title="doc update from knowledge portal" -o merge_request.target=main https://oauth2:${BOT_ACCESS_TOKEN}@gitlab.com/DetectTechnologies/${source_repo_path}.git knowledge-portal_changes
         cd -
     done
-    echo "Done"
-else
-    echo "This is not a commit that happened through knowledge portal"
 fi

--- a/knowledge-portal/source/.gitlab-ci.yml
+++ b/knowledge-portal/source/.gitlab-ci.yml
@@ -4,8 +4,9 @@ dummy-job:
 
 copy-to-central-git:
   stage: push
-  image: python
+  image: python:3.9
   script:
+    - pip3 install toml
     - bash -c "$(curl -fsSL https://github.com/detecttechnologies/Gitlab-CI-CD-Templates/raw/main/knowledge-portal/source/initiate-push-to-central.sh)"
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"

--- a/knowledge-portal/source/README.md
+++ b/knowledge-portal/source/README.md
@@ -1,4 +1,4 @@
-# Knowlege portal Source Pipeline
+# Knowlege portal Source Git
 
 ## Usage
 
@@ -17,13 +17,13 @@ variables:
   GIT_STRATEGY: clone
 
 ```
-### Using the toml file to connect to Knowledge Portal
+### Connect your Source Git repository to the Knowledge Portal
 
-Here is an example of a `docs-manifest.toml` file that you can use to create your own and connect your pipeline to knowledge portal:
+Here is an example of a `docs-manifest.toml` file that you can use to create your own and connect your repository to knowledge portal:
 
 
 ```toml
-# "includes" section maps source paths to paths at Knowledge Portal
+# "includes" section maps paths inside your source Git repository to paths that the documents should take within the Knowledge Portal
 # If a source path is a directory, all files with the .md extension within that directory (and its subdirectories) will be copied
 # If a source path is a file, only that file will be copied
 # Any folder mapping should end with '/'
@@ -53,7 +53,7 @@ Before the job in pipeline pushes files to Knowledge Portal, it checks multiple 
 - If a folder is specified in the `includes` or `excludes` sections (both source and destination), make sure to end the path with a forward slash `/`.
 - Ensure that there are no spaces in the file paths (both source and destination) and image paths that are being copied to the Knowledge Portal.
 - Check that only supported file types are being copied. Supported file types include `.md`, `.jpg`, `.png`, `.gif`, `.svg`, and `.ico`.
-- Pipeline figures out the type of image path specified in a markdown file, and converts any relative image path to absolute path before copying over to Knowledge Portal
+- Pipeline figures out the type of image path specified in a markdown file, and converts any relative image path to absolute path before copying over to Knowledge Portal. Any path starting with `http` will not be changed in the markdown file.
 
 ### Configure CI/CD variables
 

--- a/knowledge-portal/source/initiate-push-to-central.sh
+++ b/knowledge-portal/source/initiate-push-to-central.sh
@@ -2,49 +2,29 @@
 
 set -e
 
-# Run python script for pipeline checks and get mappings if all is well
-output=$(python3 -c "$(curl -fsSL https://github.com/detecttechnologies/Gitlab-CI-CD-Templates/raw/main/knowledge-portal/source/source-pipeline-checks.py)")
-echo "Done, Mappings: ${output}"
+# Set credentials
+git config --global user.email "PlatformTeam@detecttechnologies.com"
+git config --global user.name "Detect Gitlab Bot"
+git clone $CENTRAL_GIT_PUSH_URL /root/central
+
+# Run python script for pipeline checks and copy mappings to /root/central
+python3 -c "$(curl -fsSL https://github.com/detecttechnologies/Gitlab-CI-CD-Templates/raw/main/knowledge-portal/source/source-pipeline-checks.py)"
+echo "Done! Copied mappings to /root/central."
 
 # Extract the unique path (Subpath) from Repository url      
 unique_path_temp1=(${CI_REPOSITORY_URL//"gitlab.com/"/ })           # split after 'gitlab.com/' 
 unique_path_temp2=(${unique_path_temp1[1]//"."/ })                  # split before .git
 unique_path="$( cut -d '/' -f 2- <<< "${unique_path_temp2[0]}" )"   # split after first '/'
 manifest_suffix=${unique_path//"/"/_}
-echo "Done, source-repo's path: ${unique_path}, manifest suffix: ${manifest_suffix}"
+echo "Done! source-repo's path: ${unique_path}, manifest suffix: ${manifest_suffix}"
 
-# Clone the destination repo, copy the source-git's manifest to central-git by adding source-path in manifest filename
-git clone $CENTRAL_GIT_PUSH_URL /root/central
+# Copy the source-git's manifest to central-git by adding source-path in manifest filename
 mkdir -p /root/central/manifests
-cp -v docs-manifest.txt /root/central/manifests/docs-manifest_${manifest_suffix}.txt
-echo "Done, Copied manifest file to central."
-
-# Read all mappings from output and copy accordingly 
-while read line
-do
-    if [[ "$line" == *"-->"* ]]
-    then
-        source_path="${line%-->*}"
-        central_path="${line##*-->}"
-        if [[ "$central_path" == *"/"* ]]
-        then
-            echo "${central_path}"
-            path="${central_path%/*}"
-            file="${central_path##*/}"
-            mkdir -p -v /root/central/${path}
-            cp -v ${source_path} /root/central/${path}/${file}
-        else
-            cp -v ${source_path} /root/central/${central_path}
-        fi
-    fi
-done <<< ${output} 
-echo "Done. Copied all files to central"
+cp -v docs-manifest.toml /root/central/manifests/docs-manifest_${manifest_suffix}.toml
+echo "Done! Copied manifest file to /root/central."
 
 # Push back to central-git with the updated changes
 cd /root/central
-git config --global user.email "PlatformTeam@detecttechnologies.com"
-git config --global user.name "Detect Gitlab Bot"
 git add -A && git commit -m "Commit in source pipeline for ${unique_path}" --allow-empty;
 git push origin HEAD:main -f;
-echo "Done finally. Pushed files to central git."
-
+echo "Done! Pushed files to central git."


### PR DESCRIPTION
- using toml file for mapping paths
- added support for image mappings(both source and central)
- Image paths get updated to absolute path in both pipelines even if relative path is mentioned
- central pipeline to only trigger on a change from DKP using `workflow:rules`
- Source Checks: filesize, spaces, path existence,
- Central checks: filesize

Tested on `dt-iva-cicd-playground` and `demo source` repos.