### PR TITLE
Compile pipeline update: files for running job scripts, bug fixes

### DIFF
--- a/compile/python/.gitlab-ci.yml
+++ b/compile/python/.gitlab-ci.yml
@@ -1,47 +1,14 @@
-setup-binfmt:
+build_binaries:
   stage: build
-  image:
-    name: docker
-  needs: []
-  services:
-    - docker:dind
-  script:
-    - docker run --rm --privileged docker/binfmt:820fdd95a9972a5308930a2bdfb8573dd4447ad3
-  only:
-    refs:
-      - main
-      
-build-binaries:
-  stage: build
-  needs: ["setup-binfmt"]
   image: 
     name: registry.gitlab.com/detecttechnologies/platform/ci-cd-pipelines/python-ops/pythoncompiler:2.0-$PLATFORM-$VERSION
     entrypoint:  []
   before_script:
    - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.com/".insteadOf "git@gitlab.com:"
    - git submodule sync && git submodule update --init --recursive
+   - apt-get update && apt-get install curl -y
   script:
-    - ls -al .
-    - mkdir -p /app/user/load
-    - cp -R ./* /app/user/load
-    - cd /app/user/load
-    - |
-      # Exclude python files from cytonization
-      for file in $DELETE_BEFORE_COMPILING;
-        do
-          find . -wholename "$file" -exec rm -v "{}" \;
-      done
-    - cd -
-    - cd /app
-    - python3 py_compiler.py build_ext -b /app/user/load
-    - cd -
-    - |
-      cwd=$(pwd);
-      mkdir artifacts;
-      cd /app/user/load/;
-      
-      # Copy all compiled .so files to artifacts 
-      find . -wholename "**/*.so" -exec cp -v --parents \{\} $cwd/artifacts \;
+    - bash -c "$(curl -fsSL https://github.com/detecttechnologies/Gitlab-CI-CD-Templates/raw/main/compile/python/build-binaries.sh)"
   artifacts:
     paths:
       - artifacts/
@@ -56,138 +23,21 @@ build-binaries:
       - TAG: armv8
         PLATFORM: armv7
         VERSION: [py3.5,py3.6,py3.7,py3.8,py3.9,py3.10] 
-  allow_failure: true
   tags:
     - $TAG
   only:
     refs:
       - main
 
-copy-files:
-  stage: build
+push_binaries:
+  stage: push
   image: bitnami/git
   before_script:
     - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.com/".insteadOf "git@gitlab.com:"
     - git submodule sync && git submodule update --init --recursive
+    - apt-get update && apt-get install curl -y
   script:
-    - ls -al .
-    - mkdir artifacts
-    - |
-      
-      # Copy files mentioned in FILES_TO_COPY variable to artifacts
-      for file in $FILES_TO_COPY;
-      do
-        if [[ "$file" == *"-->"* ]];
-          then
-            split=(${file//-->/ });
-            cp -R -v ${split[0]} artifacts/${split[1]};
-        else
-            find . -type f -wholename "$file*" -exec cp -R -v --parents \{\} artifacts \;
-        fi       
-      done
-      # Copy all __init__ files to artifacts 
-      find . -wholename "**/__init__.py" -exec cp -v --parents \{\} artifacts \;
-  artifacts:
-    paths:
-      - artifacts/  
+    - bash -c "$(curl -fsSL https://github.com/detecttechnologies/Gitlab-CI-CD-Templates/raw/main/compile/python/push-binaries.sh)"
   only:
     refs:
       - main
-
-push-binaries:
-  stage: push
-  image: bitnami/git
-  only:
-    refs:
-      - main
-    
-  script:
-    # Setup SSH Authentication
-    - mkdir -p ~/.ssh/
-    - 'which ssh-agent || ( apt-get update -y && apt-get install openssh-client -y )'
-    - ssh-keyscan -t rsa $CI_SERVER_HOST >> ~/.ssh/known_hosts
-    - echo "${SSH_PUSH_KEY}" > ~/.ssh/id_rsa
-    - chmod 600 ~/.ssh/id_rsa
-    - git config --global user.email "PlatformTeam@detecttechnologies.com"
-    - git config --global user.name "DetectTechnologies CI"
-    - ls -al .
-    # Copy files from artifacts to their original distination and remove artifacts folder
-    - |
-      cwd=$(pwd);
-      cd artifacts;
-      find . -name "**" -exec cp -R --parents \{\} $cwd/ \;
-      cd -;
-      rm -rf artifacts;
-    # Clone destination repo to make it available as local inside pipeline
-    - git clone "${BUILD_OUTPUT_REPO}" /root/dest
-    # Remove branches from remote if the variable is assigned "true"
-    - |
-      cd /root/dest;
-      if [[ $REMOVE_BRANCHES == "true" ]];
-      then
-        git branch -r | awk -F/ '/\/linux/{print $2}' | xargs -I {} git push origin :{};
-      fi
-      cd -;
-    # Setup a branch for every unique deployment footprint, push to each of them
-    - |
-      # Find all py and arch version combinations, use them as branches
-      branch_names=$(find . -wholename "**/*.so" | sort -u | head -20 | awk -F '-' '{print $(NF-1)"-"$(NF-2)"-py"$(NF-3)}' | sort -u);
-      for branch in ${branch_names};
-      do
-        echo "-------------------------------------------";
-        echo "Now pushing branch ${branch}";
-        cd /root/dest;
-        # Switch to the branch (create if it doesn't exist), and soft reset to the previous commit;
-        git checkout --quiet ${branch} 2>/dev/null || git checkout -b ${branch};
-        git reset --soft HEAD~1 || true;
-        
-        #Delete all files before pushing
-        git rm -rf *;
-        git commit -m "removing previous builds";
-        git push --quiet origin HEAD:${branch} -f;
-        
-        # From the build folder, copy the new .so files, main.py and all __init__.py's;
-        cd -;
-        file_name_pattern=$(echo ${branch} | awk -F '-' '{print $3"-"$2"-"$1}');  # Undo the reversing carried out while forming the branch_name
-        file_name_pattern=${file_name_pattern:2};    # Remove the 'py' at the start;
-        echo "${file_name_pattern}";
-        find . -wholename "**/*${file_name_pattern}*.so" ! -wholename "./iva.**.so" -exec cp --parents \{\} /root/dest/ \;
-        cp ./main.py /root/dest/ || true;
-        find . -wholename "**/__init__.py" -exec cp --parents \{\} /root/dest/ \;
-        
-        # IVA repo specific code
-        cp ./iva.py /root/dest/ || true;
-        
-        # From the build folder, copy the files and folders mentioned in variable "FILES_TO_COPY" while ignoring .py and .so files;
-        for file in $FILES_TO_COPY;
-          do
-          if [[ "$file" == *"-->"* ]];
-          then
-            echo "hi";
-            split=(${file//-->/ });
-            cp -R -v ${split[1]} /root/dest/;
-          else
-            find . -type f -wholename "*$file*" ! -wholename "./*.so" ! -wholename "./*.py" -exec cp -R --parents \{\} /root/dest/ \;
-          fi
-          done
-        
-        #Rename filenames to original names
-        cd /root/dest;
-        for f in $(find . -type f -wholename "./**.so"); do
-           mv -v "$f" "${f/.cpython-${file_name_pattern}-gnu./.}" || mv -v "$f" "${f/.cpython-${file_name_pattern}-gnueabihf./.}";
-        done
-        
-        # Get timestamp of last commit from source repo
-        cd -;
-        timestamp=$(git log -1 --format=%cd --date=local);
-        
-        # Push back the updated repository
-        cd /root/dest;
-        git add -A && git commit -m "Commit in source pipeline at timestamp:$timestamp" --allow-empty;
-        git reflog expire --expire-unreachable=now --all;
-        git gc --prune=now;
-        # Merge all commits in one
-        git reset $(git commit-tree HEAD^{tree} -m "Commit in source pipeline at timestamp:$timestamp");
-        git push --quiet origin HEAD:${branch} -f;
-        cd -; # Switch back to the source repo before the next iteration
-      done

--- a/compile/python/build-binaries.sh
+++ b/compile/python/build-binaries.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Create directory for loading files
+mkdir -p /app/user/load
+
+# Copy all files to the loading directory
+cp -R ./* /app/user/load
+
+# Navigate to the loading directory
+cd /app/user/load
+rm -rfv scripts # So that .py files inside don't get compiled
+
+# Check if the variable $EXCLUDE_FILES is defined
+if [ -z "$EXCLUDE_FILES" ]; then
+  echo "EXCLUDE_FILES is not defined"
+else
+  # Exclude any python file from cythonization
+  for file in $EXCLUDE_FILES
+  do
+    find . -wholename "$file" -exec rm -v "{}" \;
+  done
+fi
+
+# Navigate back to the previous directory
+cd -
+
+# Navigate to the root directory
+cd /app
+
+# Compile python files using py_compiler.py
+python3 py_compiler.py build_ext -b /app/user/load
+
+# Navigate back to the previous directory
+cd -
+
+# Create directory for compiled files
+cwd=$(pwd)
+mkdir artifacts
+
+# Navigate to the loading directory
+cd /app/user/load/
+
+# Copy all compiled .so files to the artifacts directory
+find . -wholename "**/*.so" -exec cp -v --parents \{\} $cwd/artifacts \;

--- a/compile/python/push-binaries.sh
+++ b/compile/python/push-binaries.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Setup Credentials
+git config --global user.email "PlatformTeam@detecttechnologies.com"
+git config --global user.name "Detect Gitlab Bot"
+
+# Copy files from artifacts to their original distination and remove artifacts folder
+cwd=$(pwd)
+cd artifacts
+find . -name "**" -exec cp -R --parents \{\} $cwd/ \;
+cd -
+rm -rf artifacts
+
+# Clone destination repo to make it available as local inside pipeline
+git clone "https://oauth2:$BOT_ACCESS_TOKEN@gitlab.com/${BUILD_OUTPUT_REPO}" /root/dest
+
+# Remove branches from remote if the variable is assigned "true"
+cd /root/dest
+if [[ $REMOVE_BRANCHES == "true" ]]
+then
+    git branch -r | awk -F/ '/\/linux/{print $2}' | xargs -I {} git push origin :{};
+fi
+cd -
+
+# Setup a branch for every unique deployment footprint, push to each of them
+# Find all py and arch version combinations, use them as branches
+
+branch_names=$(find . -wholename "**/*.so" | sort -u | head -20 | awk -F '-' '{print $(NF-1)"-"$(NF-2)"-py"$(NF-3)}' | sort -u)
+echo "Branches to be pushed: ${branch_names}"
+
+for branch in ${branch_names}
+do  
+    echo "-------------------------------------------"
+    echo "Now pushing branch ${branch}"
+    cd /root/dest
+    
+    # Switch to the branch (create if it doesn't exist)
+    git checkout --quiet ${branch} 2>/dev/null || git checkout -b ${branch}
+
+    #Delete all files before pushing if any
+    git rm -rf * || true
+    git commit -m "removing previous builds" || true
+    git push --quiet origin HEAD:${branch} -f || true
+    cd -
+    
+    # From the build folder, copy the new .so files, main.py and all __init__.py's;
+    
+    file_name_pattern=$(echo ${branch} | awk -F '-' '{print $3"-"$2"-"$1}') # Undo the reversing carried out while forming the branch_name
+    file_name_pattern=${file_name_pattern:2}   # Remove the 'py' at the start;
+    find . -wholename "**/*${file_name_pattern}*.so" ! -wholename "./iva.**.so" -exec cp --parents \{\} /root/dest/ \;
+    cp ./main.py /root/dest/ || true
+    find . -wholename "**/__init__.py" -exec cp --parents \{\} /root/dest/ \;
+
+    # IVA repo specific code
+    cp ./iva.py /root/dest/ || true
+
+    # From the build folder, copy the files and folders mentioned in variable "COPY_FILES" while ignoring .py and .so files;
+    for file in ${COPY_FILES}
+    do
+        if [[ "$file" == *"-->"* ]]
+        then
+            split=(${file//-->/ })
+            echo "${split[0]}"
+            echo "${split[1]}"
+            cp -R -v ${split[0]} /root/dest/${split[1]}
+        else
+            find . -type f -wholename "*$file*" ! -wholename "./*.so" ! -wholename "./*.py" -exec cp -v -R --parents \{\} /root/dest/ \;
+        fi
+    done
+
+    #Rename filenames to original names
+    cd /root/dest
+    for f in $(find . -type f -wholename "./**.so") 
+    do
+        mv -v "$f" "${f/.cpython-${file_name_pattern}-gnu./.}" || mv -v "$f" "${f/.cpython-${file_name_pattern}-gnueabihf./.}"
+    done
+    cd -
+
+    # Get timestamp of last commit from source repo
+    timestamp=$(git log -1 --format=%cd --date=local)
+
+    # Push back the updated repository
+    cd /root/dest
+    
+    git add -A && git commit -m "Commit in source pipeline at timestamp:$timestamp" --allow-empty
+    git reflog expire --expire-unreachable=now --all
+    git gc --prune=now
+    
+    # Merge all commits in one
+    git reset $(git commit-tree HEAD^{tree} -m "Commit in source pipeline at timestamp:$timestamp")
+    git push --quiet origin HEAD:${branch} -f
+    
+    cd - # Switch back to the source repo before the next iteration
+    done


### PR DESCRIPTION
- instead of running commands in `.gitlab-ci.yml`. moved them to script files
-  removed copy_files jobs and instead using `git submodule sync` to get required files in push_binaries job
- changed variable names: FILES_TO_COPY-->COPY_FILES, DELETE_BEFORE_COMPILING-->EXCLUDE_FILES
- BUILD_OUTPUT_REPO CI/CD variable value needs to be updated for future jobs
- Using BOT_ACCESS_TOKEN to clone ops repo instead of ssh
- Using respective runners to run particular architecture jobs, so setup_binfmt job not neede anymore