### PR TITLE
✨ allow dkp push from other branches

### DIFF
--- a/knowledge-portal/source/.gitlab-ci.yml
+++ b/knowledge-portal/source/.gitlab-ci.yml
@@ -13,7 +13,8 @@ copy-to-central-git:
   script:
     - bash -c "$(curl -fsSL https://github.com/detecttechnologies/Gitlab-CI-CD-Templates/raw/main/knowledge-portal/source/initiate-push-to-central.sh)"
   rules:
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
-      when: manual
     - if: $CI_COMMIT_BRANCH == "main"
       when: always
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+      when: never
+    - when : manual

--- a/knowledge-portal/source/README.md
+++ b/knowledge-portal/source/README.md
@@ -17,6 +17,8 @@ variables:
   GIT_STRATEGY: clone
 
 ```
+**Note: The pipeline can be added to any branch.** On `main`, it runs automatically and on other branches, it needs to be trigerred manually. 
+
 ### Connect your Source Git repository to the Knowledge Portal
 
 Here is an example of a `docs-manifest.toml` file that you can use to create your own and connect your repository to knowledge portal:


### PR DESCRIPTION
The change makes the pipeline run
- automatically in `main`
- never on `merge_requests`
- manually on any other branch