### PR TITLE
👷 Migrate code-quality jobs to self-hosted runners

### DIFF
--- a/code-quality/docs/.gitlab-ci.yml
+++ b/code-quality/docs/.gitlab-ci.yml
@@ -3,6 +3,7 @@ stages:
 
 MR-title-check:
   stage: validate
+  tags: [dt-gitlab-runner-t3.xlarge]
   script:
     - |
       FIRST_CHAR="${CI_MERGE_REQUEST_TITLE%"${CI_MERGE_REQUEST_TITLE#?}"}"
@@ -21,14 +22,11 @@ MR-title-check:
 
 docs-spellcheck:
   stage: validate
-  image: python:slim
-  before_script:
-    - pip install codespell
-    - shopt -s globstar # Enable globbing using '*' in the shell, for the main script
+  tags: [dt-gitlab-runner-t3.xlarge]
   script:
-    - FILES_TO_SPELLCHECK=$( (ls **/*.py; ls **/*.md) | tr '\n' ' ')
-    - echo "Spellchecking the following files - ${FILES_TO_SPELLCHECK}"
-    - codespell ${FILES_TO_SPELLCHECK}
+    - |
+      docker run --rm -v "$(pwd)":/workspace -w /workspace python:slim \
+        bash -c 'pip install -q codespell && shopt -s globstar && FILES=$( (ls **/*.py; ls **/*.md) | tr "\n" " ") && codespell ${FILES}'
   rules:
     - if: '$CI_MERGE_REQUEST_LABELS =~ /skip-validation/'
       when: never
@@ -37,14 +35,11 @@ docs-spellcheck:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: always
 
-services:
-  - docker:dind
-
 docs-markdownlint:
-  image: docker:latest
   stage: validate
+  tags: [dt-gitlab-runner-t3.xlarge]
   script:
-    - docker run -v $(pwd):/workspace -w /workspace ghcr.io/igorshubovych/markdownlint-cli:latest --disable MD033 MD013 MD034 MD041 MD024 MD036 -- .
+    - docker run --rm -v "$(pwd)":/workspace -w /workspace ghcr.io/igorshubovych/markdownlint-cli:latest --disable MD033 MD013 MD034 MD041 MD024 MD036 -- .
   rules:
     - if: '$CI_MERGE_REQUEST_LABELS =~ /skip-validation/'
       when: never

--- a/code-quality/python/.gitlab-ci.yml
+++ b/code-quality/python/.gitlab-ci.yml
@@ -1,14 +1,15 @@
-# Runs ruff, black in main branch and merge_requests
+# Runs ruff, black on self-hosted runners using docker run wrappers
 stages:
   - validate
 
 # Black sub-stage in the validate stage
 cq-black:
   stage: validate
-  image: pyfound/black:latest_release
+  tags: [dt-gitlab-runner-t3.xlarge]
   script:
-    - black --diff --color --line-length 119 .
-    - black --check --verbose --line-length 119 .
+    - |
+      docker run --rm -v "$(pwd)":/workspace -w /workspace pyfound/black:latest_release \
+        sh -c "black --diff --color --line-length 119 . && black --check --verbose --line-length 119 ."
   rules:
     - if: '$CI_MERGE_REQUEST_LABELS =~ /skip-validation/'
       when: never
@@ -20,13 +21,11 @@ cq-black:
 # Ruff sub-stage in the validate stage
 cq-ruff:
   stage: validate
-  image: python:slim
-  before_script:
-    - pip install ruff
+  tags: [dt-gitlab-runner-t3.xlarge]
   script:
-    - ls .
-    - ruff check .
-    - ruff check . --output-format gitlab > gl-code-quality-report.json
+    - |
+      docker run --rm -v "$(pwd)":/workspace -w /workspace python:slim \
+        sh -c "pip install -q ruff && ruff check . && ruff check . --output-format gitlab > gl-code-quality-report.json"
   rules:
     - if: '$CI_MERGE_REQUEST_LABELS =~ /skip-validation/'
       when: never


### PR DESCRIPTION
- Add `tags: [dt-gitlab-runner-t3.xlarge]` to all jobs
- Replace `image:` directives with `docker run` wrappers (instance executor ignores image directives)
- Remove `services: docker:dind` (Docker is on the host VM)