### PR TITLE
🐛 fix push_binaries LFS handling and switch to ubuntu:22.04

### DIFF
--- a/compile/python/.gitlab-ci.yml
+++ b/compile/python/.gitlab-ci.yml
@@ -55,8 +55,8 @@ push_binaries:
         -e BUILD_OUTPUT_REPO="${BUILD_OUTPUT_REPO}" \
         -e COPY_FILES="${COPY_FILES}" \
         -e RUN_SCRIPTS="${RUN_SCRIPTS}" \
-        bitnami/git \
-        bash -c "install_packages git-lfs && git lfs install && git config --global --add safe.directory /workspace && git config --global user.email PlatformTeam@detecttechnologies.com && git config --global user.name 'Detect Gitlab Bot' && $(curl -fsSL https://github.com/detecttechnologies/Gitlab-CI-CD-Templates/raw/main/compile/python/push-binaries.sh)"
+        ubuntu:22.04 \
+        bash -c "apt-get update -qq && apt-get install -y -qq git git-lfs curl && git config --global --add safe.directory /workspace && git lfs install && git config --global user.email PlatformTeam@detecttechnologies.com && git config --global user.name 'Detect Gitlab Bot' && $(curl -fsSL https://github.com/detecttechnologies/Gitlab-CI-CD-Templates/raw/main/compile/python/push-binaries.sh)"
   only:
     refs:
       - main

--- a/compile/python/push-binaries.sh
+++ b/compile/python/push-binaries.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Copy files from artifacts to their original distination and remove artifacts folder
 cwd=$(pwd)
@@ -18,8 +19,14 @@ else
     done
 fi
 
+# Store credentials so git-lfs can authenticate to the LFS endpoint
+git config --global credential.helper store
+printf 'https://oauth2:%s@gitlab.com\n' "$BOT_ACCESS_TOKEN" > /root/.git-credentials
+
 # Clone destination repo to make it available as local inside pipeline
 git clone "https://oauth2:$BOT_ACCESS_TOKEN@gitlab.com/${BUILD_OUTPUT_REPO}" /root/dest
+# Install LFS hooks in the cloned repo so the pre-push hook uploads LFS objects
+git -C /root/dest lfs install
 
 # Remove branches from remote if the variable is assigned "true"
 cd /root/dest
@@ -95,7 +102,7 @@ do
 
     # Push back the updated repository
     cd /root/dest
-    
+
     git add -A && git commit -m "Commit in source pipeline at timestamp:$timestamp"
     
     cd -
@@ -107,6 +114,8 @@ do
 
     # Merge all commits in one
     git reset $(git commit-tree HEAD^{tree} -m "Commit in source pipeline at timestamp:$timestamp")
+    # Explicitly push LFS objects before the normal push
+    git lfs push --all origin
     git push --quiet origin HEAD:${branch} -f
     
     cd - # Switch back to the source repo before the next iteration


### PR DESCRIPTION
push-binaries.sh:
- Add set -e so push failures cause the job to fail (previously silent)
- Store BOT_ACCESS_TOKEN in credential helper so git-lfs can authenticate to the LFS endpoint during push
- Run 'git lfs install' in the cloned dest repo so the pre-push hook is available to upload LFS objects
- Add explicit 'git lfs push --all origin' before 'git push' as belt-and-suspenders for LFS upload

.gitlab-ci.yml template:
- Switch push_binaries container from bitnami/git (Photon OS) to ubuntu:22.04 (GNU coreutils, standard apt package management)