### PR TITLE
🔧 migrate code-quality jobs to t3a instance types

### DIFF
--- a/code-quality/docs/.gitlab-ci.yml
+++ b/code-quality/docs/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
 
 MR-title-check:
   stage: validate
-  tags: [dt-gitlab-runner-t3.xlarge]
+  tags: [dt-gitlab-runner-t3a.small]
   script:
     - |
       FIRST_CHAR="${CI_MERGE_REQUEST_TITLE%"${CI_MERGE_REQUEST_TITLE#?}"}"
@@ -22,7 +22,7 @@ MR-title-check:
 
 docs-spellcheck:
   stage: validate
-  tags: [dt-gitlab-runner-t3.xlarge]
+  tags: [dt-gitlab-runner-t3a.small]
   script:
     - |
       docker run --rm -v "$(pwd)":/workspace -w /workspace python:slim \
@@ -37,7 +37,7 @@ docs-spellcheck:
 
 docs-markdownlint:
   stage: validate
-  tags: [dt-gitlab-runner-t3.xlarge]
+  tags: [dt-gitlab-runner-t3a.small]
   script:
     - docker run --rm -v "$(pwd)":/workspace -w /workspace ghcr.io/igorshubovych/markdownlint-cli:latest --disable MD033 MD013 MD034 MD041 MD024 MD036 -- .
   rules:

--- a/code-quality/python/.gitlab-ci.yml
+++ b/code-quality/python/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
 # Black sub-stage in the validate stage
 cq-black:
   stage: validate
-  tags: [dt-gitlab-runner-t3.xlarge]
+  tags: [dt-gitlab-runner-t3a.small]
   script:
     - |
       docker run --rm -v "$(pwd)":/workspace -w /workspace pyfound/black:latest_release \
@@ -21,7 +21,7 @@ cq-black:
 # Ruff sub-stage in the validate stage
 cq-ruff:
   stage: validate
-  tags: [dt-gitlab-runner-t3.xlarge]
+  tags: [dt-gitlab-runner-t3a.small]
   script:
     - |
       docker run --rm -v "$(pwd)":/workspace -w /workspace python:slim \

--- a/compile/python/.gitlab-ci.yml
+++ b/compile/python/.gitlab-ci.yml
@@ -2,7 +2,7 @@
 build-check-submodules:
   stage: validate
   tags:
-    - dt-gitlab-runner-t3.xlarge
+    - dt-gitlab-runner-t3a.xlarge
   script:
     - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.com/".insteadOf "git@gitlab.com:"
     - git submodule sync && git submodule update --init --recursive
@@ -12,7 +12,7 @@ build-check-submodules:
 build_binaries:
   stage: build
   tags:
-    - dt-gitlab-runner-t3.xlarge
+    - dt-gitlab-runner-t3a.xlarge
   before_script:
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY 2>/dev/null || true
     - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.com/".insteadOf "git@gitlab.com:"
@@ -38,7 +38,7 @@ build_binaries:
 push_binaries:
   stage: push
   tags:
-    - dt-gitlab-runner-t3.xlarge
+    - dt-gitlab-runner-t3a.xlarge
   before_script:
     - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.com/".insteadOf "git@gitlab.com:"
     - git submodule sync && git submodule update --init --recursive


### PR DESCRIPTION
- build/push jobs: dt-gitlab-runner-t3a.xlarge
- code quality jobs: dt-gitlab-runner-t3a.small