### PR TITLE
👷 Split dashboard runner tags for instance vs Docker executors

### DIFF
--- a/dashboard-templates/backend.gitlab-ci.yml
+++ b/dashboard-templates/backend.gitlab-ci.yml
@@ -13,13 +13,13 @@ stages:
 
 default:
   tags:
-    - amd64
+    - amd64-docker
 
 build_image:
   stage: build
   image: docker:25
   tags:
-    - amd64
+    - amd64-docker
   services: 
     - docker:dind
   script:
@@ -111,7 +111,7 @@ deploy_docker:
     DOCKER_DRIVER: overlay2
     DOCKER_AUTH_CONFIG: '{"auths":{"registry.gitlab.com":{"username":"${CI_CD_API_USER}","password":"${CI_CD_API_TOKEN}"}}}'
   tags:
-    - amd64
+    - amd64-docker
   environment:
     name: $LIFECYCLE_STAGE
   script:
@@ -129,7 +129,7 @@ migrations:
   variables:
     DOCKER_AUTH_CONFIG: '{"auths":{"registry.gitlab.com":{"username":"${CI_CD_API_USER}","password":"${CI_CD_API_TOKEN}"}}}'
   tags:
-    - amd64
+    - amd64-docker
   environment:
     name: $LIFECYCLE_STAGE
   script:

--- a/dashboard-templates/frontend.gitlab-ci.yml
+++ b/dashboard-templates/frontend.gitlab-ci.yml
@@ -11,12 +11,12 @@ stages:
 
 default:
   tags:
-    - amd64
+    - amd64-docker
 
 build_package:
   stage: build
   tags:
-    - saas-linux-medium-amd64
+    - amd64
   image: node:16.14.2
   script:
     - |


### PR DESCRIPTION
👷 Split dashboard runner tags (FE → amd64, DinD → amd64-docker)

⚙️ Changes:
1. FE builds → `amd64` (instance pool)
2. DinD / deploy / migrations / default → `amd64-docker` (interim)
3. `build_package`: `saas-linux-medium-amd64` → `amd64`
